### PR TITLE
Issue76 improve scan save for qt3scan application

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "numpy>=1.21.2",
     "matplotlib>=3.4.3",
     "scipy>=1.7.1",
+    "h5py>=3.3.0",
     "qcsapphire>=1.0.1",
     "qt3rfsynthcontrol>=1.0.1",
     "nipiezojenapy>=1.0.1",

--- a/src/applications/piezoscan.py
+++ b/src/applications/piezoscan.py
@@ -12,7 +12,6 @@ import nidaqmx
 
 import qt3utils.nidaq
 import qt3utils.datagenerators as datasources
-import qt3utils.datagenerators.piezoscanner
 import qt3utils.pulsers.pulseblaster
 import nipiezojenapy
 
@@ -543,7 +542,7 @@ def build_data_scanner():
                                                             args.rwtimeout,
                                                             args.signal_counter)
 
-    scanner = qt3utils.datagenerators.piezoscanner.CounterAndScanner(data_acq, stage_controller)
+    scanner = datasources.CounterAndScanner(data_acq, stage_controller)
 
     return scanner
 

--- a/src/applications/piezoscan.py
+++ b/src/applications/piezoscan.py
@@ -1,18 +1,13 @@
-import time
 import argparse
-import collections
 import tkinter as tk
-import tkinter.ttk as ttk
 import logging
 import datetime
 from threading import Thread
 
 import numpy as np
-import scipy.optimize
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 import matplotlib
-matplotlib.use('Agg')
 import nidaqmx
 
 import qt3utils.nidaq
@@ -20,6 +15,8 @@ import qt3utils.datagenerators as datasources
 import qt3utils.datagenerators.piezoscanner
 import qt3utils.pulsers.pulseblaster
 import nipiezojenapy
+
+matplotlib.use('Agg')
 
 
 parser = argparse.ArgumentParser(description='NI DAQ (PCIx 6363) / Jena Piezo Scanner',
@@ -86,10 +83,10 @@ class ScanImage:
     def update(self, model):
 
         if self.log_data:
-            data = np.log10(model.data)
+            data = np.log10(model.scanned_count_rate)
             data[np.isinf(data)] = 0 #protect against +-inf
         else:
-            data = model.data
+            data = model.scanned_count_rate
 
         self.artist = self.ax.imshow(data, cmap=self.cmap, extent=[model.xmin,
                                                                    model.xmax + model.step_size,
@@ -116,6 +113,7 @@ class ScanImage:
         if event.inaxes is self.ax:
             #todo: draw a circle around clicked point? Maybe with a high alpha, so that its faint
             self.onclick_callback(event)
+
 
 class SidePanel():
     def __init__(self, root, scan_range):
@@ -230,7 +228,6 @@ class SidePanel():
 
         self.log10Button = tk.Button(frame, text="Log10")
         self.log10Button.grid(row=row, column=2, pady=(2,15))
-
 
     def update_go_to_position(self, x = None, y = None, z = None):
         if x is not None:
@@ -349,14 +346,14 @@ class MainTkApplication():
     def set_color_map(self, event = None):
         #Is there a way for this function to exist entirely in the view code instead of here?
         self.view.scan_view.cmap = self.view.sidepanel.mpl_color_map_entry.get()
-        if len(self.model.data) > 0:
+        if len(self.model.scanned_count_rate) > 0:
             self.view.scan_view.update(self.model)
             self.view.canvas.draw()
 
     def log_scan_image(self, event = None):
         #Is there a way for this function to exist entirely in the view code instead of here?
         self.view.scan_view.log_data = not self.view.scan_view.log_data
-        if len(self.model.data) > 0:
+        if len(self.model.scanned_count_rate) > 0:
             self.view.scan_view.update(self.model)
             self.view.canvas.draw()
 
@@ -459,7 +456,7 @@ class MainTkApplication():
         if afile is None or afile == '':
            return #selection was canceled.
         with open(afile, 'wb') as f_object:
-          np.save(f_object, self.model.data)
+          np.save(f_object, self.model.scanned_count_rate)
 
         self.view.sidepanel.saveScanButton['state'] = 'normal'
 
@@ -531,7 +528,8 @@ class MainTkApplication():
 def build_data_scanner():
     if args.randomtest:
         stage_controller = nipiezojenapy.BaseControl()
-        scanner = datasources.RandomPiezoScanner(stage_controller=stage_controller)
+        data_acq = datasources.RandomRateCounter(simulate_single_light_source=True,
+                                                 num_data_samples_per_batch=args.num_data_samples_per_batch)
     else:
         stage_controller = nipiezojenapy.PiezoControl(device_name = args.daq_name,
                                   write_channels = args.piezo_write_channels.split(','),
@@ -545,7 +543,7 @@ def build_data_scanner():
                                                             args.rwtimeout,
                                                             args.signal_counter)
 
-        scanner = datasources.NiDaqPiezoScanner(data_acq, stage_controller)
+    scanner = qt3utils.datagenerators.piezoscanner.CounterAndScanner(data_acq, stage_controller)
 
     return scanner
 
@@ -553,6 +551,7 @@ def build_data_scanner():
 def main():
     tkapp = MainTkApplication(build_data_scanner())
     tkapp.run()
+
 
 if __name__ == '__main__':
     main()

--- a/src/applications/piezoscan.py
+++ b/src/applications/piezoscan.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 import matplotlib
 import nidaqmx
+import h5py
 
 import qt3utils.nidaq
 import qt3utils.datagenerators as datasources
@@ -449,15 +450,30 @@ class MainTkApplication():
         self.scan_thread.start()
 
     def save_scan(self, event = None):
-        myformats = [('Numpy Array', '*.npy')]
-        afile = tk.filedialog.asksaveasfilename(filetypes = myformats, defaultextension = '.npy')
+        myformats = [('Compressed Numpy MultiArray', '*.npz'), ('Numpy Array', '*.npy'), ('HDF5', '*.h5')]
+        afile = tk.filedialog.asksaveasfilename(filetypes=myformats, defaultextension='.npz')
         logger.info(afile)
+        file_type = afile.split('.')[-1]
         if afile is None or afile == '':
-           return #selection was canceled.
-        with open(afile, 'wb') as f_object:
-          np.save(f_object, self.counter_scanner.scanned_count_rate)
+            return # selection was canceled.
 
-        self.view.sidepanel.saveScanButton['state'] = 'normal'
+        data = dict(raw_counts=self.counter_scanner.scanned_raw_counts,
+                    count_rate=self.counter_scanner.scanned_count_rate,
+                    scan_range=self.counter_scanner.get_completed_scan_range(),
+                    step_size=self.counter_scanner.step_size)
+
+        if file_type == 'npy':
+            np.save(afile, data['count_rate'])
+
+        if file_type == 'npz':
+            np.savez_compressed(afile, **data)
+
+        elif file_type == 'h5':
+            h5file = h5py.File(afile, 'w')
+            for key, value in data.items():
+                h5file.create_dataset(key, data=value)
+            h5file.close()
+
 
     def optimize_thread_function(self, axis, central, range, step_size):
 

--- a/src/applications/piezoscan.py
+++ b/src/applications/piezoscan.py
@@ -450,17 +450,20 @@ class MainTkApplication():
         self.scan_thread.start()
 
     def save_scan(self, event = None):
-        myformats = [('Compressed Numpy MultiArray', '*.npz'), ('Numpy Array', '*.npy'), ('HDF5', '*.h5')]
+        myformats = [('Compressed Numpy MultiArray', '*.npz'), ('Numpy Array (count rate only)', '*.npy'), ('HDF5', '*.h5')]
         afile = tk.filedialog.asksaveasfilename(filetypes=myformats, defaultextension='.npz')
         logger.info(afile)
         file_type = afile.split('.')[-1]
         if afile is None or afile == '':
             return # selection was canceled.
 
-        data = dict(raw_counts=self.counter_scanner.scanned_raw_counts,
+        data = dict(
+                    raw_counts=self.counter_scanner.scanned_raw_counts,
                     count_rate=self.counter_scanner.scanned_count_rate,
                     scan_range=self.counter_scanner.get_completed_scan_range(),
-                    step_size=self.counter_scanner.step_size)
+                    step_size=self.counter_scanner.step_size,
+                    daq_clock_rate=self.counter_scanner.rate_counter.clock_rate,
+                    )
 
         if file_type == 'npy':
             np.save(afile, data['count_rate'])

--- a/src/qt3utils/datagenerators/__init__.py
+++ b/src/qt3utils/datagenerators/__init__.py
@@ -1,3 +1,5 @@
 from .daqsamplers import RandomRateCounter
 from .daqsamplers import NiDaqDigitalInputRateCounter
-from .piezoscanner import NiDaqPiezoScanner, RandomPiezoScanner
+from .piezoscanner import CounterAndScanner
+from .piezoscanner import CounterAndScanner as NiDaqPiezoScanner
+from .piezoscanner import CounterAndScanner as RandomPiezoScanner

--- a/src/qt3utils/datagenerators/daqsamplers.py
+++ b/src/qt3utils/datagenerators/daqsamplers.py
@@ -137,12 +137,15 @@ class RateCounterBase(abc.ABC):
 
 
 class RandomRateCounter(RateCounterBase):
-
-    '''
+    """
     This random source acts like a light source with variable intensity.
 
     This is similar to a PL source moving in and out of focus.
-    '''
+
+    When 'simulated_single_light_source' is True at instantiation,
+    this will simulate a sample with isolated bright spots, like NV centers in diamond and
+    is used when testing the CounterAndScanner class in piezoscanner.py module.
+    """
     def __init__(self, simulate_single_light_source=False, num_data_samples_per_batch=10):
         super().__init__()
         self.default_offset = 100

--- a/src/qt3utils/datagenerators/daqsamplers.py
+++ b/src/qt3utils/datagenerators/daqsamplers.py
@@ -10,11 +10,12 @@ import qt3utils.nidaq
 logger = logging.getLogger(__name__)
 
 class RateCounterBase(abc.ABC):
-
+    """
+    Subclasses must implement a clock_rate attribute or property.
+    """
     def __init__(self):
-        self.clock_rate = 1 # default clock rate
         self.running = False
-
+        self.clock_rate = 0
     def stop(self):
         """
         subclasses may override this for custom behavior
@@ -34,27 +35,92 @@ class RateCounterBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def sample_counts(self, n_samples = 1) -> np.ndarray:
+    def _read_samples(self):
         """
-        Should return a numpy array of size n_samples, with each row being
-        an array (or tuple) of two values, The first value is equal to the number of counts,
-        and the second value is the number of clock samples that were used to measure the counts.
+        subclasses must implement this method
 
-        Example, if n_samples = 3
-        data = [
-                [22, 5], # 22 counts were observed in 5 clock samples
-                [24, 5],
-                [20, 4] # this data indicates there was an error with data acquisition - 4 clock samples were observed.
-               ]
+        Should return total_counts, num_clock_samples
         """
         pass
+
+    def sample_counts(self, n_batches=1, sum_counts=True):
+        """
+        Performs n_batches of batch reads from _read_samples method.
+
+        This is useful when hardware (such as NIDAQ) is pre-configured to acquire a fixed number of samples
+        and the caller wishes to read more data than the number of samples acquired.
+        For example, if the NiDAQ is configured to acquire 1000 clock samples, but the caller
+        wishes to read 10000 samples, then this function may be called with n_batches=10.
+
+        For each batch read (of size `num_data_samples_per_batch`), the
+        total counts are summed. Because it's possible (though unlikely)
+        for the hardware to return fewer than `num_data_samples_per_batch` measurements,
+        the actual number of data samples per batch are also recorded.
+
+        If sum_counts is False, a numpy array of shape (n_batches, 2) is returned, where
+        the first element is the sum of the counts, and the second element is
+        the actual number of clock samples per batch. This may be useful for the caller if
+        they wish to perform their own averaging or other statistical analysis that may be time dependent.
+
+        For example, if `num_data_samples_per_batch` is 5 and n_batches is 3,
+        (typical values are 100 and 10, 100 and 1, 1000 and 1, etc)
+
+        reading counts from the NiDAQ may return
+
+        #sample 1
+        raw_counts_1 = [3,5,4,6,4]
+        sum_counts_1 = 22
+        size_counts_1 = 5
+           (22, 5)
+        #sample 2
+        raw_counts_2 = [5,5,7,3,4]
+        sum_counts_2 = 24
+        size_counts_2 = 5
+           (24, 5)
+        #sample 3
+        raw_counts_3 = [5,3,5,7]
+        sum_counts_3 = 20
+        size_counts_2 = 4
+           (20, 4)
+
+        In this example, the numpy array is of shape (3, 2) and will be
+        data = [
+                [22, 5],
+                [24, 5],
+                [20, 4]
+               ]
+
+        If sum_counts is True, then will the total number of counts and total number of
+        clock samples read will be returned.
+
+        np.sum(data, axis=0, keepdims=True).
+
+        In the example above, this would be [[66, 14]].
+
+        With these data, and knowing the clock_rate, one can easily compute
+        the count rate. See sample_count_rate.
+        """
+
+        data = np.zeros((n_batches, 2))
+        for i in range(n_batches):
+            data_sample, samples_read = self._read_samples()
+            if samples_read > 0:
+                data[i][0] = np.sum(data_sample[:samples_read])
+            data[i][1] = samples_read
+            logger.info(f'batch data (sum counts, num clock cycles per batch): {data[i]}')
+
+        if sum_counts:
+            return np.sum(data, axis=0, keepdims=True)
+        else:
+            return data
 
     def sample_count_rate(self, data_counts: np.ndarray):
         """
         Converts the output of sample_counts to a count rate. Expects data_counts to be a 2d numpy array
-        of [[counts, clock_samples], [counts, clock_samples], ...] as is returned by sample_counts.
+        of [[counts, clock_samples], [counts, clock_samples], ...] or a 2d array with one row: [[counts, clock_samples]]
+        as is returned by sample_counts.
 
-        Under normal conditions, will return a single value
+        Returns the count rate in counts/second = clock_rate * total counts/ total clock_samples)
 
         If the sum of all clock_samples is 0, will return np.nan.
         """
@@ -63,7 +129,6 @@ class RateCounterBase(abc.ABC):
             return self.clock_rate * _data[0]/_data[1]
         else:
             return np.nan
-
 
     def yield_count_rate(self):
         while self.running:
@@ -78,32 +143,41 @@ class RandomRateCounter(RateCounterBase):
 
     This is similar to a PL source moving in and out of focus.
     '''
-    def __init__(self):
+    def __init__(self, simulate_single_light_source=False, num_data_samples_per_batch=10):
         super().__init__()
         self.default_offset = 100
-        self.signal_noise_amp  = 0.2
-        self.possible_offset_values = np.arange(0, 1000, 50)
+        self.signal_noise_amp = 0.2
 
         self.current_offset = self.default_offset
         self.current_direction = 1
-        self.running = False
+        self.clock_rate = 0.9302010 # a totally random number :P
+        self.simulate_single_light_source = simulate_single_light_source
+        self.possible_offset_values = np.arange(5000, 100000, 1000)  # these create the "bright" positions
+        self.num_data_samples_per_batch = num_data_samples_per_batch
 
-    def sample_counts(self, n_samples = 1):
+    def _read_samples(self):
         """
         Returns a random number of counts
         """
-        if np.random.random(1)[0] < 0.05:
-            if np.random.random(1)[0] < 0.1:
-                self.current_direction = -1 * self.current_direction
-            self.current_offset += self.current_direction*np.random.choice(self.possible_offset_values)
+        if self.simulate_single_light_source:
+            if np.random.random(1)[0] < 0.005:
+                self.current_offset = np.random.choice(self.possible_offset_values)
+            else:
+                self.current_offset = self.default_offset
 
-        if self.current_offset < self.default_offset:
-            self.current_offset = self.default_offset
-            self.current_direction = 1
+        else:
+            if np.random.random(1)[0] < 0.05:
+                if np.random.random(1)[0] < 0.1:
+                    self.current_direction = -1 * self.current_direction
+                self.current_offset += self.current_direction*np.random.choice(self.possible_offset_values)
 
-        counts = self.signal_noise_amp*self.current_offset*np.random.random(n_samples) + self.current_offset
-        count_size = np.ones(n_samples)
-        return np.column_stack((counts, count_size))
+            if self.current_offset < self.default_offset:
+                self.current_offset = self.default_offset
+                self.current_direction = 1
+
+        counts = self.signal_noise_amp * self.current_offset * np.random.random(self.num_data_samples_per_batch) + self.current_offset
+
+        return counts, self.num_data_samples_per_batch
 
 
 class NiDaqDigitalInputRateCounter(RateCounterBase):
@@ -126,7 +200,6 @@ class NiDaqDigitalInputRateCounter(RateCounterBase):
         self.read_write_timeout = read_write_timeout
         self.num_data_samples_per_batch = num_data_samples_per_batch
         self.trigger_terminal = trigger_terminal
-        self.running = False
 
         self.read_lock = False
 
@@ -188,7 +261,6 @@ class NiDaqDigitalInputRateCounter(RateCounterBase):
             self.read_lock = False
             return data_buffer, samples_read
 
-
     def start(self):
         if self.running:
             self.stop()
@@ -208,12 +280,12 @@ class NiDaqDigitalInputRateCounter(RateCounterBase):
     def stop(self):
         if self.running:
             while self.read_lock:
-                time.sleep(0.1) #wait for current read to complete
+                time.sleep(0.1) # wait for current read to complete
 
             if self.nidaq_config.clock_task:
                 self._burn_and_log_exception(self.nidaq_config.clock_task.stop)
-                self._burn_and_log_exception(self.nidaq_config.clock_task.close) #close the task to free resource on NIDAQ
-            #self._burn_and_log_exception(self.nidaq_config.counter_task.stop) #will need to stop task if we move to continuous buffered acquisition
+                self._burn_and_log_exception(self.nidaq_config.clock_task.close) # close the task to free resource on NIDAQ
+            # self._burn_and_log_exception(self.nidaq_config.counter_task.stop) # will need to stop task if we move to continuous buffered acquisition
             self._burn_and_log_exception(self.nidaq_config.counter_task.close)
 
         self.running = False
@@ -221,63 +293,6 @@ class NiDaqDigitalInputRateCounter(RateCounterBase):
     def close(self):
         self.stop()
 
-    def sample_counts(self, n_samples = 1):
-        '''
-        Performs n_samples of batch reads from the NiDAQ.
 
-        For each batch read (of size `num_data_samples_per_batch`), the
-        total counts are summed. Additionally, because it's possible (though unlikely)
-        for the NiDAQ to return fewer than `num_data_samples_per_batch` measurements,
-        the actual number of data samples per batch are also recorded.
 
-        Finally, a numpy array of shape (n_samples, 2) is returned, where
-        the first element is the sum of the counts, and the second element is
-        the actual number of data samples per batch.
-
-        For example, if `num_data_samples_per_batch` is 5 and n_samples is 3,
-        (typical values are 100 and 10, 100 and 1, 1000 and 1, etc)
-
-        reading counts from the NiDAQ may return
-
-        #sample 1
-        raw_counts_1 = [3,5,4,6,4]
-        sum_counts_1 = 22
-        size_counts_1 = 5
-           (22, 5)
-        #sample 2
-        raw_counts_2 = [5,5,7,3,4]
-        sum_counts_2 = 24
-        size_counts_2 = 5
-           (24, 5)
-        #sample 3
-        raw_counts_3 = [5,3,5,7]
-        sum_counts_3 = 20
-        size_counts_2 = 4
-           (20, 4)
-
-        In this example, the numpy array is of shape (3, 2) and will be
-        data = [
-                [22, 5],
-                [24, 5],
-                [20, 4]
-               ]
-
-        With these data, and knowing the clock_rate, one can easily compute
-        the count rate
-
-        #removes rows where num samples per batch were zero (which would be a bug in the code)
-        data = data[np.where(data[:,1] > 0)]
-
-        #count rate is the mean counts per clock cycle multiplied by the clock rate.
-        count_rate = clock_rate * data[:,0]/data[:,1]
-        '''
-
-        data = np.zeros((n_samples, 2))
-        for i in range(n_samples):
-            data_sample, samples_read = self._read_samples()
-            if samples_read > 0:
-                data[i][0] = np.sum(data_sample[:samples_read])
-            data[i][1] = samples_read
-            logger.info(f'batch data (sum counts, num clock cycles per batch): {data[i]}')
-        return data
 

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -66,6 +66,20 @@ class CounterAndScanner:
         self.xmin = xmin
         self.xmax = xmax
 
+    def get_scan_range(self) -> tuple:
+        """
+        Returns a tuple of the full scan range
+        :return: xmin, xmax, ymin, ymax
+        """
+        return self.xmin, self.xmax, self.ymin, self.ymax
+
+    def get_completed_scan_range(self) -> tuple:
+        """
+        Returns a tuple of the scan range that has been completed
+        :return: xmin, xmax, ymin, current_y
+        """
+        return self.xmin, self.xmax, self.ymin, self.current_y
+
     def still_scanning(self):
         if self.running == False: #this allows external process to stop scan
             return False

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -132,7 +132,8 @@ class CounterAndScanner:
 
     def reset(self):
         self.scanned_raw_counts = []
-
+        self.scanned_count_rate = []
+        
     def optimize_position(self, axis, center_position, width = 2, step_size = 0.25):
         '''
         Performs a scan over a particular axis about `center_position`.

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -71,6 +71,13 @@ class BasePiezoScanner(abc.ABC):
                 logger.info(f'out of range\n\n{e}')
 
     @abc.abstractmethod
+    def sample_counts(self):
+        '''
+        must return an array-like object
+        '''
+        pass
+
+    @abc.abstractmethod
     def sample_count_rate(self):
         '''
         must return an array-like object
@@ -168,8 +175,13 @@ class NiDaqPiezoScanner(BasePiezoScanner):
     def set_num_data_samples_per_batch(self, N):
         self.nidaqratecounter.num_data_samples_per_batch = N
 
-    def sample_count_rate(self):
-        return self.nidaqratecounter.sample_count_rate(self.num_daq_batches)
+    def sample_counts(self):
+        return self.nidaqratecounter.sample_counts(self.num_daq_batches)
+
+    def sample_count_rate(self, data_counts=None):
+        if data_counts is None:
+            data_counts = self.sample_counts()
+        return self.nidaqratecounter.sample_count_rate(data_counts)
 
     def stop(self):
         self.nidaqratecounter.stop()
@@ -195,17 +207,24 @@ class RandomPiezoScanner(BasePiezoScanner):
         self.possible_offset_values = np.arange(5000, 100000, 1000)
 
         self.current_offset = self.default_offset
+        self.clock_period = 0.09302010  # a totally random number
 
     def set_num_data_samples_per_batch(self, N):
         #for the random sampler, there is only one sample per batch. So, we set
         #number of batches here
         self.num_daq_batches = N
 
-    def sample_count_rate(self):
-        #time.sleep(.25) #simulate time for data acquisition
+
+    def sample_counts(self):
         if np.random.random(1)[0] < 0.005:
             self.current_offset = np.random.choice(self.possible_offset_values)
         else:
             self.current_offset = self.default_offset
 
-        return self.signal_noise_amp*self.current_offset*np.random.random(self.num_daq_batches) + self.current_offset
+        return self.signal_noise_amp * self.current_offset * np.random.random(
+            self.num_daq_batches) + self.current_offset
+
+    def sample_count_rate(self, data_counts = None):
+        if data_counts is None:
+            data_counts = self.sample_counts()
+        return data_counts / self.clock_period

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -1,4 +1,3 @@
-import abc
 import numpy as np
 import scipy.optimize
 import time
@@ -10,29 +9,33 @@ def gauss(x, *p):
     C, mu, sigma, offset = p
     return C*np.exp(-(x-mu)**2/(2.*sigma**2)) + offset
 
-class BasePiezoScanner(abc.ABC):
-    def __init__(self, stage_controller = None):
+
+class CounterAndScanner:
+    def __init__(self, rate_counter, stage_controller):
 
         self.running = False
-
         self.current_y = 0
         self.ymin = 0.0
         self.ymax = 80.0
         self.xmin = 0.0
         self.xmax = 80.0
         self.step_size = 0.5
-        self.raster_line_pause = 0.0
+        self.raster_line_pause = 0.150  # wait 150ms for the piezo stage to settle before a line scan
 
-        self.data = []
+        self.scanned_raw_counts = []
+        self.scanned_count_rate = []
+
         self.stage_controller = stage_controller
-
-        self.num_daq_batches = 1 #could change to 10 if want 10x more samples for each position
+        self.rate_counter = rate_counter
+        self.num_daq_batches = 1 # could change to 10 if want 10x more samples for each position
 
     def stop(self):
+        self.rate_counter.stop()
         self.running = False
 
     def start(self):
         self.running = True
+        self.rate_counter.start()
 
     def set_to_starting_position(self):
         self.current_y = self.ymin
@@ -40,7 +43,18 @@ class BasePiezoScanner(abc.ABC):
             self.stage_controller.go_to_position(x = self.xmin, y = self.ymin)
 
     def close(self):
-        return
+        self.rate_counter.close()
+
+    def set_num_data_samples_per_batch(self, N):
+        self.rate_counter.num_data_samples_per_batch = N
+
+    def sample_counts(self):
+        return self.rate_counter.sample_counts(self.num_daq_batches)
+
+    def sample_count_rate(self, data_counts=None):
+        if data_counts is None:
+            data_counts = self.sample_counts()
+        return self.rate_counter.sample_count_rate(data_counts)
 
     def set_scan_range(self, xmin, xmax, ymin, ymax):
         if self.stage_controller:
@@ -70,47 +84,40 @@ class BasePiezoScanner(abc.ABC):
             except ValueError as e:
                 logger.info(f'out of range\n\n{e}')
 
-    @abc.abstractmethod
-    def sample_counts(self):
-        """
-        expectation is to return [[counts, clock_samples], [counts, clock_samples], ...] as is returned by daqsamplers.sample_counts.
-        """
-        pass
-
-    @abc.abstractmethod
-    def sample_count_rate(self):
-        """
-        must return a single floating point value
-        """
-        pass
-
-    @abc.abstractmethod
-    def set_num_data_samples_per_batch(self, N):
-        pass
-
     def scan_x(self):
+        """
+        Scans the x axis from xmin to xmax in steps of step_size.
 
-        scan = self.scan_axis('x', self.xmin, self.xmax, self.step_size)
-        self.data.append(scan)
+        Stores results in self.scanned_raw_counts and self.scanned_count_rate.
+        """
+        raw_counts_for_axis = self.scan_axis('x', self.xmin, self.xmax, self.step_size)
+        self.scanned_raw_counts.append(raw_counts_for_axis)
+        self.scanned_count_rate.append([self.sample_count_rate(raw_counts) for raw_counts in raw_counts_for_axis])
 
     def scan_axis(self, axis, min, max, step_size):
-        scan = []
+        """
+        Moves the stage along the specified axis from min to max in steps of step_size.
+        Returns a list of raw counts from the scan in the shape
+        [[[counts, clock_samples]], [[counts, clock_samples]], ...] where each [[counts, clock_samples]] is the
+        result of a single call to sample_counts at each scan position along the axis.
+        """
+        raw_counts = []
         self.stage_controller.go_to_position(**{axis:min})
         time.sleep(self.raster_line_pause)
         for val in np.arange(min, max, step_size):
             if self.stage_controller:
                 logger.info(f'go to position {axis}: {val:.2f}')
                 self.stage_controller.go_to_position(**{axis:val})
-            cr = self.sample_count_rate()
-            scan.append(cr)
-            logger.info(f'count rate: {cr}')
+            _raw_counts = self.sample_counts()
+            raw_counts.append(_raw_counts)
+            logger.info(f'raw counts, total clock samples: {_raw_counts}')
             if self.stage_controller:
                 logger.info(f'current position: {self.stage_controller.get_current_position()}')
 
-        return scan
+        return raw_counts
 
     def reset(self):
-        self.data = []
+        self.scanned_raw_counts = []
 
     def optimize_position(self, axis, center_position, width = 2, step_size = 0.25):
         '''
@@ -147,15 +154,16 @@ class BasePiezoScanner(abc.ABC):
             max_val = np.min([max_val, 80.0])
 
         self.start()
-        data = self.scan_axis(axis, min_val, max_val, step_size)
+        raw_counts = self.scan_axis(axis, min_val, max_val, step_size)
         self.stop()
         axis_vals = np.arange(min_val, max_val, step_size)
+        count_rate = self.sample_count_rate(raw_counts)
 
-        optimal_position = axis_vals[np.argmax(data)]
+        optimal_position = axis_vals[np.argmax(count_rate)]
         coeff = None
-        params = [np.max(data), optimal_position, 1.0, np.min(data)]
+        params = [np.max(count_rate), optimal_position, 1.0, np.min(count_rate)]
         try:
-            coeff, var_matrix = scipy.optimize.curve_fit(gauss, axis_vals, data, p0=params)
+            coeff, var_matrix = scipy.optimize.curve_fit(gauss, axis_vals, count_rate, p0=params)
             optimal_position = coeff[1]
             # ensure that the optimal position is within the scan range
             optimal_position = np.max([min_val, optimal_position])
@@ -163,68 +171,5 @@ class BasePiezoScanner(abc.ABC):
         except RuntimeError as e:
             print(e)
 
-        return data, axis_vals, optimal_position, coeff
+        return count_rate, axis_vals, optimal_position, coeff
 
-class NiDaqPiezoScanner(BasePiezoScanner):
-    def __init__(self, nidaqratecounter, stage_controller, num_data_samples_per_batch = 50):
-        super().__init__(stage_controller)
-        self.nidaqratecounter = nidaqratecounter
-        self.raster_line_pause = 0.150  #wait 150ms for the piezo stage to settle before a line scan
-        self.set_num_data_samples_per_batch(num_data_samples_per_batch)
-
-    def set_num_data_samples_per_batch(self, N):
-        self.nidaqratecounter.num_data_samples_per_batch = N
-
-    def sample_counts(self):
-        return self.nidaqratecounter.sample_counts(self.num_daq_batches)
-
-    def sample_count_rate(self, data_counts=None):
-        if data_counts is None:
-            data_counts = self.sample_counts()
-        return self.nidaqratecounter.sample_count_rate(data_counts)
-
-    def stop(self):
-        self.nidaqratecounter.stop()
-        super().stop()
-
-    def start(self):
-        super().start()
-        self.nidaqratecounter.start()
-
-    def close(self):
-        super().close()
-        self.nidaqratecounter.close()
-
-class RandomPiezoScanner(BasePiezoScanner):
-    '''
-    This random scanner acts like it finds bright light sources
-    at random positions across a scan.
-    '''
-    def __init__(self, stage_controller = None):
-        super().__init__(stage_controller)
-        self.default_offset = 350
-        self.signal_noise_amp  = 0.2
-        self.possible_offset_values = np.arange(5000, 100000, 1000)  # these create the "bright" positions
-
-        self.current_offset = self.default_offset
-        self.clock_period = 0.09302010  # a totally random number
-
-    def set_num_data_samples_per_batch(self, N):
-        #for the random sampler, there is only one sample per batch. So, we set
-        #number of batches here
-        self.num_daq_batches = N
-
-
-    def sample_counts(self):
-        if np.random.random(1)[0] < 0.005:
-            self.current_offset = np.random.choice(self.possible_offset_values)
-        else:
-            self.current_offset = self.default_offset
-
-        return self.signal_noise_amp * self.current_offset * np.random.random(
-            self.num_daq_batches) + self.current_offset
-
-    def sample_count_rate(self, data_counts = None):
-        if data_counts is None:
-            data_counts = self.sample_counts()
-        return np.sum(data_counts) / self.clock_period

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -72,16 +72,16 @@ class BasePiezoScanner(abc.ABC):
 
     @abc.abstractmethod
     def sample_counts(self):
-        '''
-        must return an array-like object
-        '''
+        """
+        expectation is to return [[counts, clock_samples], [counts, clock_samples], ...] as is returned by daqsamplers.sample_counts.
+        """
         pass
 
     @abc.abstractmethod
     def sample_count_rate(self):
-        '''
-        must return an array-like object
-        '''
+        """
+        must return a single floating point value
+        """
         pass
 
     @abc.abstractmethod
@@ -101,7 +101,7 @@ class BasePiezoScanner(abc.ABC):
             if self.stage_controller:
                 logger.info(f'go to position {axis}: {val:.2f}')
                 self.stage_controller.go_to_position(**{axis:val})
-            cr = np.mean(self.sample_count_rate())
+            cr = self.sample_count_rate()
             scan.append(cr)
             logger.info(f'count rate: {cr}')
             if self.stage_controller:
@@ -204,7 +204,7 @@ class RandomPiezoScanner(BasePiezoScanner):
         super().__init__(stage_controller)
         self.default_offset = 350
         self.signal_noise_amp  = 0.2
-        self.possible_offset_values = np.arange(5000, 100000, 1000)
+        self.possible_offset_values = np.arange(5000, 100000, 1000)  # these create the "bright" positions
 
         self.current_offset = self.default_offset
         self.clock_period = 0.09302010  # a totally random number
@@ -227,4 +227,4 @@ class RandomPiezoScanner(BasePiezoScanner):
     def sample_count_rate(self, data_counts = None):
         if data_counts is None:
             data_counts = self.sample_counts()
-        return data_counts / self.clock_period
+        return np.sum(data_counts) / self.clock_period

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -184,7 +184,7 @@ class CounterAndScanner:
             optimal_position = np.max([min_val, optimal_position])
             optimal_position = np.min([max_val, optimal_position])
         except RuntimeError as e:
-            print(e)
+            logger.warning(e)
 
         return count_rates, axis_vals, optimal_position, coeff
 


### PR DESCRIPTION
Fixes Issue #76  -- Vastly improves scan data saving options. 

Adds support for h5 and npz (numpy multi array compressed) file formats.

Also, it was desirable to save the raw counts for each point in the scan rather than holding the count rates. With just the 
count rates, a poisson standard deviation cannot be computed. The npz and h5 formats contain 

`raw_counts` - an array of shape [n_rows, n_cols, 1, 2], where for each position in n_rows, n_cols, which represents the y, x position in scan, there is a 1,2 array that contains total_counts, total_clock_samples
`count_rate` - an array of shape [n_rows, n_cols], where each position represents the count rate at the location y, x
`scan_range` - an array holding (x_min, x_max, y_min, y_max) where y_max is the last y value scanned. Values are in microns (though these units are not specified in the files yet)
`step_size` - an array of size 1 holding the delta between x, y positions (in microns)
`daq_clock_rate` - an array of size 1 holding the clock frequency of the DAQ device

One can compute the count_rate from the raw_counts with the following numpy command

``` 
clock_rate * raw_counts.sum(axis=2)[:,:,0] / raw_counts.sum(axis=2)[:,:,1]
```

In order to deliver the raw_counts to the qt3scan application (piezoscan.py), a number of changes were made in
the datagenerqators sub package. These changes unified the NIDAQ and Random data generator subclasses so they operate
in the same manner. Additionally, because of this unification and definition of the datagenerators.RateCounterBase class, the piezoscanner.py module was vastly simplified to one class that is instantiated with instances of the subclasses, RateCounterBase and nipiezojenapy.BaseControl. This significantly opens the opportunity to later define different DAQ hardware and stage controller hardware that qt3scan can accept -- thus one can imagine repurposing this application for other hardware. (NB: the current implementation is not perfect, however...see issue #79)
