### PR TITLE
Add piezo controller scale and range options to qt3scan. Issue #105

### DIFF
--- a/src/applications/piezoscan.py
+++ b/src/applications/piezoscan.py
@@ -62,10 +62,8 @@ parser.add_argument('-pb', '--pulse-blaster', metavar = '<PB board number>', def
                     help='Pulse Blaster board number')
 parser.add_argument('-pmin', '--piezo-min-position', metavar = 'microns', default = 0, type=float,
                     help='sets min allowed position on piezo controller.')
-
 parser.add_argument('-pmax', '--piezo-max-position', metavar = 'microns', default = 80, type=float,
                     help='sets min allowed position on piezo controller.')
-
 parser.add_argument('-pscale', '--piezo-scale-microns-per-volt', default = 8, type=float,
                     help='sets micron to volt scale for piezo controller.')
 

--- a/src/applications/piezoscan.py
+++ b/src/applications/piezoscan.py
@@ -60,6 +60,14 @@ parser.add_argument('-cmap', metavar = '<MPL color>', default = 'gray',
                     help='Set the MatplotLib colormap scale')
 parser.add_argument('-pb', '--pulse-blaster', metavar = '<PB board number>', default = 0, type=int,
                     help='Pulse Blaster board number')
+parser.add_argument('-pmin', '--piezo-min-position', metavar = 'microns', default = 0, type=float,
+                    help='sets min allowed position on piezo controller.')
+
+parser.add_argument('-pmax', '--piezo-max-position', metavar = 'microns', default = 80, type=float,
+                    help='sets min allowed position on piezo controller.')
+
+parser.add_argument('-pscale', '--piezo-scale-microns-per-volt', default = 8, type=float,
+                    help='sets micron to volt scale for piezo controller.')
 
 args = parser.parse_args()
 
@@ -551,7 +559,10 @@ def build_data_scanner():
     else:
         stage_controller = nipiezojenapy.PiezoControl(device_name = args.daq_name,
                                   write_channels = args.piezo_write_channels.split(','),
-                                  read_channels = args.piezo_read_channels.split(','))
+                                  read_channels = args.piezo_read_channels.split(','),
+                                  min_position = args.piezo_min_position,
+                                  max_position = args.piezo_max_position,
+                                  scale_microns_per_volt = args.piezo_scale_microns_per_volt)
 
         data_acq = datasources.NiDaqDigitalInputRateCounter(args.daq_name,
                                                             args.signal_terminal,

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -15,10 +15,10 @@ class CounterAndScanner:
 
         self.running = False
         self.current_y = 0
-        self.ymin = 0.0
-        self.ymax = 80.0
-        self.xmin = 0.0
-        self.xmax = 80.0
+        self.ymin = stage_controller.minimum_allowed_position
+        self.ymax = stage_controller.maximum_allowed_position
+        self.xmin = stage_controller.minimum_allowed_position
+        self.xmax = stage_controller.maximum_allowed_position
         self.step_size = 0.5
         self.raster_line_pause = 0.150  # wait 150ms for the piezo stage to settle before a line scan
 


### PR DESCRIPTION
Add piezo controller scale and range options to qt3scan via issue #105: https://github.com/qt3uw/qt3-utils/issues/105. This was also done in nipiezeojenapy: https://github.com/qt3uw/nipiezeojenapy/pull/11. This was done for different piezeos in different labs to be used. Tested and confirmed that it works on the SiV microscope in QDL. 