### PR TITLE
Updates QT3Scan to use new nipiezojenapy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "h5py>=3.3.0",
     "qcsapphire>=1.0.1",
     "qt3rfsynthcontrol>=1.0.1",
-    "nipiezojenapy>=1.0.1",
+    "nipiezojenapy>=1.0.3",
     "pulseblaster>=1.0.1",
 ]
 

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -177,7 +177,7 @@ class CounterAndScanner:
         optimal_position = axis_vals[np.argmax(count_rates)]
         coeff = None
         params = [np.max(count_rates), optimal_position, 1.0, np.min(count_rates)]
-        bounds = (len(params)*tuple((0,)), len(params)*tuple((np.inf,)))
+        bounds = ((0, -np.inf, 0, 0), (np.inf, np.inf, np.inf, np.inf))
         try:
             coeff, var_matrix = scipy.optimize.curve_fit(gauss, axis_vals, count_rates, p0=params, bounds=bounds)
             optimal_position = coeff[1]


### PR DESCRIPTION
The latest version of nipiezojenapy (1.0.3) supports independent voltage/micron scales along each channel/axis (x, y, z). 

This was needed to support the ARS microscope. 

This change also supports optimization fits to positions with negative values. Previously, the scipy fit function was called with bounds on parameters that required the best-fit position to be a positive value. Now the best-fit position can be a negative value as well. This supports the ARS microscope. 

This was tested on the ARS microscope with the help of @Waffelz. Before merging, it would be prudent to test this on another microscope -- either QLM in QT3 or perhaps the SiV microscope. 
 