### PR TITLE
Hyperspectral bug fixes

### DIFF
--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -117,10 +117,12 @@ class QT3ScanConfocalApplicationController:
         self.daq_and_scanner.move_y()
 
     @convert_nidaq_daqnotfounderror(module_logger)
-    def optimize_position(self, axis: str,
-                          central: float,
-                          range: float,
-                          step_size: float) -> Tuple[np.ndarray, np.ndarray, float, np.ndarray]:
+    def optimize_position(
+            self, axis: str,
+            central: float,
+            range: float,
+            step_size: float
+    ) -> Tuple[np.ndarray, np.ndarray, float, np.ndarray]:
         """
         The returned tuple elements should be:
         0th: np.ndarray of count rates across the axis
@@ -137,7 +139,7 @@ class QT3ScanConfocalApplicationController:
         return self.daq_and_scanner.get_completed_scan_range()
 
     @staticmethod
-    def allowed_file_save_formats(self) -> list:
+    def allowed_file_save_formats() -> list:
         """
         Returns a list of tuples of the allowed file save formats
             [(description, file_extension), ...]
@@ -147,7 +149,7 @@ class QT3ScanConfocalApplicationController:
         return formats
 
     @staticmethod
-    def default_file_format(self) -> str:
+    def default_file_format() -> str:
         """
         Returns the default file format
         """
@@ -193,10 +195,12 @@ class QT3ScanHyperSpectralApplicationController:
      Note that the DAQ controller here must implement QT3ScanSpectrometerDAQControllerInterface
     """
 
-    def __init__(self,
-                 position_controller: QT3ScanPositionControllerInterface,
-                 daq_controller: QT3ScanSpectrometerDAQControllerInterface,
-                 logger_level: int) -> None:
+    def __init__(
+            self,
+            position_controller: QT3ScanPositionControllerInterface,
+            daq_controller: QT3ScanSpectrometerDAQControllerInterface,
+            logger_level: int
+    ) -> None:
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logger_level)
@@ -294,7 +298,7 @@ class QT3ScanHyperSpectralApplicationController:
         if self.running is False:  # this allows external process to stop scan
             return False
 
-        if self.current_y < self.ymax:  # stops scan when reaches final position
+        if self.current_y <= self.ymax:  # stops scan when reaches final position
             return True
         else:
             self.running = False
@@ -353,7 +357,7 @@ class QT3ScanHyperSpectralApplicationController:
         self.position_controller.go_to_position(**{axis: min})
         time.sleep(self.raster_line_pause)
 
-        for val in np.arange(min, max, step_size):
+        for val in np.arange(min, max + step_size, step_size):
             self.position_controller.go_to_position(**{axis: val})
             measured_spectrum, measured_wavelengths = self.daq_controller.sample_spectrum()
 
@@ -376,7 +380,7 @@ class QT3ScanHyperSpectralApplicationController:
         return np.array(spectrums_in_scan), wavelength_array
 
     def move_y(self) -> None:
-        if self.current_y < self.ymax:
+        if self.current_y <= self.ymax:
             self._current_y += self.step_size
         try:
             self.position_controller.go_to_position(y=self.current_y)
@@ -442,7 +446,7 @@ class QT3ScanHyperSpectralApplicationController:
                 pickle.dump(data, f)
 
     @staticmethod
-    def allowed_file_save_formats(self) -> list:
+    def allowed_file_save_formats() -> list:
         """
         Returns a list of tuples of the allowed file save formats
             [(description, file_extension), ...]
@@ -455,7 +459,7 @@ class QT3ScanHyperSpectralApplicationController:
         return formats
 
     @staticmethod
-    def default_file_format(self) -> str:
+    def default_file_format() -> str:
         """
         Returns the default file format
         """

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -98,6 +98,10 @@ class QT3ScanConfocalApplicationController:
         self.daq_and_scanner.stop()
 
     @convert_nidaq_daqnotfounderror(module_logger)
+    def post_stop(self) -> None:
+        self.daq_and_scanner.post_stop()
+
+    @convert_nidaq_daqnotfounderror(module_logger)
     def reset(self) -> None:
         self.daq_and_scanner.reset()
 
@@ -278,10 +282,17 @@ class QT3ScanHyperSpectralApplicationController:
 
     def stop(self) -> None:
         """
-        This method is used to stop the scan. It should stop the hardware from acquiring data.
+        This method is used to stop the scan. It should stop the scanning loop.
+        """
+        self.running = False
+
+    def post_stop(self) -> None:
+        """
+        This method is called after the scan is stopped.
+        It should do the necessary cleanup.
+        For example, it should stop the DAQ.
         """
         self.daq_controller.stop()
-        self.running = False
 
     def reset(self) -> None:
         """

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -1,16 +1,15 @@
 import logging
-import numpy as np
-from typing import Tuple
-import h5py
 import pickle
 import time
 import tkinter as tk
+from typing import Tuple
 
+import h5py
 import matplotlib
+import numpy as np
+from matplotlib import pyplot as plt
 from matplotlib.backend_bases import MouseEvent
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-import matplotlib.pyplot as plt
-matplotlib.use('Agg')
 
 from qt3utils.applications.qt3scan.interface import (
     QT3ScanDAQControllerInterface,
@@ -22,6 +21,9 @@ from qt3utils.applications.qt3scan.interface import (
 import qt3utils.datagenerators
 from qt3utils.errors import convert_nidaq_daqnotfounderror, QT3Error
 
+
+matplotlib.use('Agg')
+
 module_logger = logging.getLogger(__name__)
 module_logger.setLevel(logging.ERROR)
 
@@ -32,6 +34,7 @@ class QT3ScanConfocalApplicationController:
 
     Note that the DAQ controller here must implement QT3ScanCounterDAQControllerInterface
     """
+
     def __init__(self,
                  position_controller: QT3ScanPositionControllerInterface,
                  daq_controller: QT3ScanCounterDAQControllerInterface,
@@ -133,30 +136,33 @@ class QT3ScanConfocalApplicationController:
     def get_completed_scan_range(self) -> Tuple[float, float, float, float]:
         return self.daq_and_scanner.get_completed_scan_range()
 
+    @staticmethod
     def allowed_file_save_formats(self) -> list:
-        '''
+        """
         Returns a list of tuples of the allowed file save formats
             [(description, file_extension), ...]
-        '''
-        formats = [('Compressed Numpy MultiArray', '*.npz'), ('Numpy Array (count rate only)', '*.npy'), ('HDF5', '*.h5')]
+        """
+        formats = [('Compressed Numpy MultiArray', '*.npz'), ('Numpy Array (count rate only)', '*.npy'),
+                   ('HDF5', '*.h5')]
         return formats
 
+    @staticmethod
     def default_file_format(self) -> str:
-        '''
+        """
         Returns the default file format
-        '''
+        """
         return '.npz'
 
     def save_scan(self, afile_name) -> None:
         file_type = afile_name.split('.')[-1]
 
         data = dict(
-                    scan_range=self.get_completed_scan_range(),
-                    raw_counts=self.daq_and_scanner.scanned_raw_counts,
-                    count_rate=self.daq_and_scanner.scanned_count_rate,
-                    step_size=self.daq_and_scanner.step_size,
-                    daq_clock_rate=self.daq_controller.clock_rate,
-                    )
+            scan_range=self.get_completed_scan_range(),
+            raw_counts=self.daq_and_scanner.scanned_raw_counts,
+            count_rate=self.daq_and_scanner.scanned_count_rate,
+            step_size=self.daq_and_scanner.step_size,
+            daq_clock_rate=self.daq_controller.clock_rate,
+        )
 
         if file_type == 'npy':
             np.save(afile_name, data['count_rate'])
@@ -186,6 +192,7 @@ class QT3ScanHyperSpectralApplicationController:
 
      Note that the DAQ controller here must implement QT3ScanSpectrometerDAQControllerInterface
     """
+
     def __init__(self,
                  position_controller: QT3ScanPositionControllerInterface,
                  daq_controller: QT3ScanSpectrometerDAQControllerInterface,
@@ -207,7 +214,7 @@ class QT3ScanHyperSpectralApplicationController:
         self._step_size = 0.5
         self.raster_line_pause = 0.150  # wait 150ms for the piezo stage to settle before a line scan
 
-        self.hyper_spectral_raw_data = None  # is there way to create a "default numpy array", similar a 'default dict'??
+        self.hyper_spectral_raw_data = None  # is there way to create a "default numpy array", similar a 'default dict'?
         self.hyper_spectral_wavelengths = None
 
     @property
@@ -275,14 +282,13 @@ class QT3ScanHyperSpectralApplicationController:
     def reset(self) -> None:
         """
         Resets internal data structure. NB: this blows away any previously stored data.
-
         """
         self.hyper_spectral_raw_data = None
         self.hyper_spectral_wavelengths = None
 
     def set_to_starting_position(self) -> None:
         self._current_y = self.ymin
-        self.position_controller.go_to_position(x = self.xmin, y = self.ymin)
+        self.position_controller.go_to_position(x=self.xmin, y=self.ymin)
 
     def still_scanning(self) -> bool:
         if self.running is False:  # this allows external process to stop scan
@@ -297,7 +303,6 @@ class QT3ScanHyperSpectralApplicationController:
     def scan_x(self):
         """
         Scans the x axis from xmin to xmax in steps of step_size.
-
         """
         raw_counts_for_axis, wavelengths = (
             self.scan_axis('x', self.xmin, self.xmax, self.step_size)
@@ -362,7 +367,8 @@ class QT3ScanHyperSpectralApplicationController:
             if initial_spectrum_size != len(measured_wavelengths):
                 raise QT3Error("Inconsistent wavelength array size obtained during scan! Check your hardware.")
             if len(measured_spectrum) != len(measured_wavelengths):
-                raise QT3Error("Inconsistent wavelength array and spectrum size obtained during scan! Check your hardware.")
+                raise QT3Error(
+                    "Inconsistent wavelength array and spectrum size obtained during scan! Check your hardware.")
             if np.array_equal(wavelength_array, measured_wavelengths) is False:
                 raise QT3Error("Inconsistent wavelength array obtained during scan! Check your hardware.")
             spectrums_in_scan.append(measured_spectrum)
@@ -377,19 +383,21 @@ class QT3ScanHyperSpectralApplicationController:
         except ValueError as e:
             self.logger.info(f'move y: out of range\n\n{e}')
 
-    def optimize_position(self, axis: str,
-                            central: float,
-                            range: float,
-                            step_size: float) -> Tuple[np.ndarray, np.ndarray, float, np.ndarray]:
+    def optimize_position(
+            self, axis: str,
+            central: float,
+            range: float,
+            step_size: float
+    ) -> Tuple[np.ndarray, np.ndarray, float, np.ndarray]:
         """
         Not Yet Implemented.
         """
         raise NotImplementedError("QT3ScanHyperSpectralApplicationController does not implement optimize_position")
 
     def set_scan_range(self, xmin: float, xmax: float, ymin: float, ymax: float) -> None:
-        '''
+        """
         This method is used to set the scan range and is called in qt3scan.main
-        '''
+        """
         self.position_controller.check_allowed_position(xmin, ymin)
         self.position_controller.check_allowed_position(xmax, ymax)
 
@@ -433,11 +441,12 @@ class QT3ScanHyperSpectralApplicationController:
             with open(afile_name, 'wb') as f:
                 pickle.dump(data, f)
 
+    @staticmethod
     def allowed_file_save_formats(self) -> list:
-        '''
+        """
         Returns a list of tuples of the allowed file save formats
             [(description, file_extension), ...]
-        '''
+        """
         formats = [('Compressed Numpy MultiArray', '*.npz'),
                    ('Numpy Array (count rate only)', '*.npy'),
                    ('HDF5', '*.h5'),
@@ -445,15 +454,16 @@ class QT3ScanHyperSpectralApplicationController:
                    ]
         return formats
 
+    @staticmethod
     def default_file_format(self) -> str:
-        '''
+        """
         Returns the default file format
-        '''
+        """
         return '.npz'
 
     def scan_image_rightclick_event(self, event: MouseEvent, index_x: int, index_y: int) -> None:
         """
-        This method is called when the user right clicks on the scan image.
+        This method is called when the user right-clicks on the scan image.
         """
         self.logger.debug(f"Mouse Event {event}")
 
@@ -466,7 +476,8 @@ class QT3ScanHyperSpectralApplicationController:
         ax.set_xlabel('Wavelength (nm)')
         ax.set_ylabel('Counts / bin')
 
-        self.logger.debug(f'Selecting {index_y}, {index_x} from hyper spectral array of shape {self.hyper_spectral_raw_data.shape}')
+        self.logger.debug(
+            f'Selecting {index_y}, {index_x} from hyper spectral array of shape {self.hyper_spectral_raw_data.shape}')
         selected_spectrum = self.hyper_spectral_raw_data[index_y, index_x, :]
 
         ax.plot(self.hyper_spectral_wavelengths, selected_spectrum, label='data')

--- a/src/qt3utils/applications/qt3scan/interface.py
+++ b/src/qt3utils/applications/qt3scan/interface.py
@@ -1,6 +1,7 @@
 import tkinter as Tk
-import numpy as np
 from typing import Tuple, Optional, Protocol, runtime_checkable
+
+import numpy as np
 from matplotlib.backend_bases import MouseEvent
 
 
@@ -303,9 +304,9 @@ class QT3ScanApplicationControllerInterface(Protocol):
         pass
 
     def set_scan_range(self, xmin: float, xmax: float, ymin: float, ymax: float) -> None:
-        '''
+        """
         This method is used to set the scan range and is called in qt3scan.main
-        '''
+        """
         pass
 
     def save_scan(self) -> None:
@@ -321,16 +322,16 @@ class QT3ScanApplicationControllerInterface(Protocol):
         pass
 
     def allowed_file_save_formats(self) -> list:
-        '''
+        """
         Returns a list of tuples of the allowed file save formats
             [(description, file_extension), ...]
-        '''
+        """
         pass
 
     def default_file_format(self) -> str:
-        '''
+        """
         Returns the default file format
-        '''
+        """
         pass
 
     def scan_image_rightclick_event(self, event: MouseEvent, index_x: int, index_y: int) -> None:

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -1,34 +1,34 @@
 import argparse
-import tkinter as tk
-import logging
 import datetime
-from threading import Thread
 import importlib.resources
+import logging
+import tkinter as tk
+from threading import Thread
 from typing import Any, Protocol, Optional, Callable, List
 
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-from matplotlib.backend_bases import MouseEvent
 import matplotlib
 import nidaqmx
+import numpy as np
 import yaml
+from matplotlib import pyplot as plt
+from matplotlib.backend_bases import MouseEvent
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 
 import qt3utils.nidaq
 import qt3utils.pulsers.pulseblaster
-from qt3utils.applications.qt3scan.interface import (
-    QT3ScanDAQControllerInterface,
-    QT3ScanPositionControllerInterface,
-    QT3ScanApplicationControllerInterface,
-)
 from qt3utils.applications.qt3scan.controller import (
     QT3ScanConfocalApplicationController,
     QT3ScanHyperSpectralApplicationController
 )
 from qt3utils.applications.controllers.utils import make_popup_window_and_take_threaded_action
+from qt3utils.applications.qt3scan.interface import (
+    QT3ScanDAQControllerInterface,
+    QT3ScanPositionControllerInterface,
+    QT3ScanApplicationControllerInterface,
+)
+
 
 matplotlib.use('Agg')
-
 
 parser = argparse.ArgumentParser(description='QT3Scan', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-v', '--verbose', type=int, default=2, help='0 = quiet, 1 = info, 2 = debug.')
@@ -88,6 +88,7 @@ CONFIG_FILE_DAQ_CONTROLLER = 'DAQController'
 
 
 class ScanImage:
+
     def __init__(self, mplcolormap: str = 'gray'):
         self.fig, self.ax = plt.subplots()
         self.cbar = None
@@ -215,7 +216,8 @@ class ScanImage:
             self.fig.canvas.draw()
 
 
-class SidePanel():
+class SidePanel:
+
     def __init__(self, application):
         frame = tk.Frame(application.root_window)
         frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
@@ -358,7 +360,8 @@ class SidePanel():
         self.y_max_entry.insert(10, scan_range[1])
 
 
-class MainApplicationView():
+class MainApplicationView:
+
     def __init__(self, application):
         frame = tk.Frame(application.root_window)
         frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
@@ -410,7 +413,7 @@ class MainApplicationView():
                                y_vals: np.ndarray,
                                fit_coeff: np.ndarray = None) -> None:
         """
-        Consturcts a new window with a plot of the optimization data.
+        Constructs a new window with a plot of the optimization data.
 
         title: title of the window
         old_opt_value: the old optimized value
@@ -445,7 +448,7 @@ class MainApplicationView():
         canvas.draw()
 
 
-class MainTkApplication():
+class MainTkApplication:
 
     def __init__(self, application_controller_name: str):
         self.root_window = tk.Tk()
@@ -751,9 +754,9 @@ class MainTkApplication():
         self.application_controller.save_scan(afile)
 
     def _optimize_thread_function(self, axis: str, central: float, range: float, step_size: float) -> None:
-        '''
+        """
         This function is called by the optimize function. It is not intended to be called directly.
-        '''
+        """
 
         try:
             data, axis_vals, opt_pos, coeff = self.application_controller.optimize_position(axis,

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -683,7 +683,7 @@ class MainTkApplication:
                 self.view.scan_view.update(self.application_controller)
                 self.view.canvas.draw()
 
-            self.application_controller.stop()
+            self.application_controller.post_stop()
 
         except nidaqmx.errors.DaqError as e:
             logger.warning(e)

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -124,7 +124,7 @@ class ScanImage:
         self.artist = self.ax.imshow(data, origin='lower',
                                      cmap=self.cmap,
                                      extent=[app_controller.xmin - app_controller.step_size / 2.0,
-                                             app_controller.xmax - app_controller.step_size / 2.0,
+                                             app_controller.xmax + app_controller.step_size / 2.0,
                                              app_controller.ymin - app_controller.step_size / 2.0,
                                              app_controller.current_y - app_controller.step_size / 2.0])
 

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -31,8 +31,10 @@ class CounterAndScanner:
         self.num_daq_batches = 1  # could change to 10 if want 10x more samples for each position
 
     def stop(self):
-        self.rate_counter.stop()
         self.running = False
+
+    def post_stop(self):
+        self.rate_counter.stop()
 
     def start(self):
         self.running = True
@@ -169,6 +171,7 @@ class CounterAndScanner:
         self.start()
         raw_counts = self.scan_axis(axis, min_val, max_val, step_size)
         self.stop()
+        self.post_stop()
         axis_vals = np.arange(min_val, max_val, step_size)
         count_rates = [self.sample_count_rate(count) for count in raw_counts]
 

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -5,9 +5,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def gauss(x, *p):
     C, mu, sigma, offset = p
-    return C*np.exp(-(x-mu)**2/(2.*sigma**2)) + offset
+    return C * np.exp(-(x - mu) ** 2 / (2. * sigma ** 2)) + offset
 
 
 class CounterAndScanner:
@@ -27,7 +28,7 @@ class CounterAndScanner:
 
         self.stage_controller = stage_controller
         self.rate_counter = rate_counter
-        self.num_daq_batches = 1 # could change to 10 if want 10x more samples for each position
+        self.num_daq_batches = 1  # could change to 10 if want 10x more samples for each position
 
     def stop(self):
         self.rate_counter.stop()
@@ -40,11 +41,10 @@ class CounterAndScanner:
     def set_to_starting_position(self):
         self.current_y = self.ymin
         if self.stage_controller:
-            self.stage_controller.go_to_position(x = self.xmin, y = self.ymin)
+            self.stage_controller.go_to_position(x=self.xmin, y=self.ymin)
 
     def close(self):
         self.rate_counter.close()
-
 
     def sample_counts(self):
         return self.rate_counter.sample_counts(self.num_daq_batches)
@@ -79,17 +79,17 @@ class CounterAndScanner:
         return self.xmin, self.xmax, self.ymin, self.current_y
 
     def still_scanning(self):
-        if self.running == False: #this allows external process to stop scan
+        if self.running == False:  # this allows external process to stop scan
             return False
 
-        if self.current_y < self.ymax: #stops scan when reaches final position
+        if self.current_y <= self.ymax:  # stops scan when reaches final position
             return True
         else:
             self.running = False
             return False
 
     def move_y(self):
-        if self.stage_controller and self.current_y < self.ymax:
+        if self.stage_controller and self.current_y <= self.ymax:
             self.current_y += self.step_size
             try:
                 self.stage_controller.go_to_position(y=self.current_y)
@@ -114,12 +114,12 @@ class CounterAndScanner:
         result of a single call to sample_counts at each scan position along the axis.
         """
         raw_counts = []
-        self.stage_controller.go_to_position(**{axis:min})
+        self.stage_controller.go_to_position(**{axis: min})
         time.sleep(self.raster_line_pause)
-        for val in np.arange(min, max, step_size):
+        for val in np.arange(min, max + step_size, step_size):
             if self.stage_controller:
                 logger.info(f'go to position {axis}: {val:.2f}')
-                self.stage_controller.go_to_position(**{axis:val})
+                self.stage_controller.go_to_position(**{axis: val})
             _raw_counts = self.sample_counts()
             raw_counts.append(_raw_counts)
             logger.info(f'raw counts, total clock samples: {_raw_counts}')
@@ -132,8 +132,8 @@ class CounterAndScanner:
         self.scanned_raw_counts = []
         self.scanned_count_rate = []
 
-    def optimize_position(self, axis, center_position, width = 2, step_size = 0.25):
-        '''
+    def optimize_position(self, axis, center_position, width=2, step_size=0.25):
+        """
         Performs a scan over a particular axis about `center_position`.
 
         The scan ranges from center_position +- width and progresses with step_size.
@@ -156,7 +156,7 @@ class CounterAndScanner:
         and the fit_coeff is set to None.
         When the fit is successful, x_optimal = mu.
 
-        '''
+        """
         min_val = center_position - width
         max_val = center_position + width
         if self.stage_controller:
@@ -186,4 +186,3 @@ class CounterAndScanner:
             logger.warning(e)
 
         return count_rates, axis_vals, optimal_position, coeff
-


### PR DESCRIPTION
In this small PR, I reformatted some of the qt3scan code to abide better to python PEP 8, and fixed two issues in logic:
1. When scanning, neither x nor y included the final point in the range. This is now fixed.
2. The scanning stopping logic was off, since the stop method was used both to terminate the scan and close the devices. This is a problem because we do not immediately stop the scan, but rather wait until the entire line is finished, and then complete the scan. Now there is a separate method called post_stop that allows the user to do any post-termination processes they wish. 
