### PR TITLE
New features for Qt3Scans

### DIFF
--- a/src/qt3utils/applications/controllers/princeton_spectrometer.yaml
+++ b/src/qt3utils/applications/controllers/princeton_spectrometer.yaml
@@ -9,7 +9,7 @@ QT3Scan:
       grating_selected : "[500nm,300][2][0]" # Varies based on spectrometer type
       starting_wavelength : 600
       ending_wavelength : 850
-      experiment_name: "LF_Control"
+      experiment_name: "ZnOTrueShinySide"
 
   PositionController:
     import_path : qt3utils.applications.controllers.nidaqpiezocontroller

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -240,6 +240,7 @@ class QT3ScanConfocalApplicationController:
             count_rate=self.daq_and_scanner.scanned_count_rate,
             step_size=self.daq_and_scanner.step_size,
             daq_clock_rate=self.data_clock_rate,
+            bg_raw_counts=self.raw_bg_counts,
             daq_config=self.data_configs['DAQ'],
             scanner_config=self.data_configs['Scanner'],
         )
@@ -300,6 +301,7 @@ class QT3ScanConfocalApplicationController:
         self.daq_and_scanner.step_size = data_dict.get('step_size', 0.5)
         self.daq_and_scanner.ymax = self.daq_and_scanner.current_y - self.daq_and_scanner.step_size
         self.data_clock_rate = data_dict.get('daq_clock_rate', None)
+        self.raw_bg_counts = data_dict.get('bg_raw_counts', 0.)
         self.data_configs['DAQ'] = data_dict.get('daq_config', None)
         self.data_configs['Scanner'] = data_dict.get('scanner_config', None)
         self.data_saved_once = False

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -120,7 +120,8 @@ class QT3ScanConfocalApplicationController:
 
     @property
     def scanned_count_rate(self) -> np.ndarray:
-        return self.daq_and_scanner.scanned_count_rate - self.raw_bg_counts * self.data_clock_rate
+        data_clock_rate = self.data_clock_rate if self.data_clock_rate is not None else np.nan
+        return self.daq_and_scanner.scanned_count_rate - self.raw_bg_counts * data_clock_rate
 
     @property
     def scanned_raw_counts(self) -> np.ndarray:
@@ -363,7 +364,8 @@ class QT3ScanHyperSpectralApplicationController:
     @property
     def scanned_count_rate(self) -> np.ndarray:
         if not self.counts_aggregation_option.startswith('Axes'):
-            return self.scanned_raw_counts * self.data_clock_rate
+            data_clock_rate = self.data_clock_rate if self.data_clock_rate is not None else np.nan
+            return self.scanned_raw_counts * data_clock_rate
         else:
             return self.scanned_raw_counts
 

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -440,7 +440,7 @@ class QT3ScanHyperSpectralApplicationController:
         if self.hyper_spectral_raw_data is not None:
             wl_min, wl_max = min(self.filter_view_range), max(self.filter_view_range)
             wls = self.hyper_spectral_wavelengths
-            data_in_range = np.float_(self.hyper_spectral_raw_data[:, :, (wls >= wl_min) & (wls <= wl_max)])
+            data_in_range = np.float64(self.hyper_spectral_raw_data[:, :, (wls >= wl_min) & (wls <= wl_max)])
             data_in_range -= self.raw_bg_counts
             wls_in_range = wls[(wls >= wl_min) & (wls <= wl_max)]
             return self.counts_aggregation_method(wls_in_range, data_in_range)

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -58,7 +58,7 @@ def weighted_mean_wavelength(wavelengths, spectra):
 
             # Calculate weighted mean using counts as weights
             try:
-                mean_wavelengths[x, y] = np.average(wavelengths, weights=spectrum)
+                mean_wavelengths[x, y] = np.average(wavelengths, weights=spectrum - np.min(spectrum))
             except ZeroDivisionError:
                 # Avoids error if filtered range is off the available wavelength limits
                 # and there are no data to be processed
@@ -808,6 +808,9 @@ class QT3ScanHyperSpectralApplicationController:
             # ax.axvline(min_range, color='k', linestyle='--')
             # ax.axvline(max_range, color='k', linestyle='--')
             ax.axvspan(min_range, max_range, alpha=0.1, color='k')
+
+        if self.counts_aggregation_option == 'Axes-Weighted-Mean':
+            ax.axvline(self.scanned_raw_counts[index_y, index_x], alpha=0.5, color='r')
 
         canvas = FigureCanvasTkAgg(fig, master=win)
         canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=True)

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -121,11 +121,11 @@ class QT3ScanConfocalApplicationController:
     @property
     def scanned_count_rate(self) -> np.ndarray:
         data_clock_rate = self.data_clock_rate if self.data_clock_rate is not None else np.nan
-        return self.daq_and_scanner.scanned_count_rate - self.raw_bg_counts * data_clock_rate
+        return np.array(self.daq_and_scanner.scanned_count_rate) - self.raw_bg_counts * data_clock_rate
 
     @property
     def scanned_raw_counts(self) -> np.ndarray:
-        return self.daq_and_scanner.scanned_raw_counts - self.raw_bg_counts
+        return np.array(self.daq_and_scanner.scanned_raw_counts) - self.raw_bg_counts
 
     @property
     def position_controller(self) -> QT3ScanPositionControllerInterface:

--- a/src/qt3utils/applications/qt3scan/controller.py
+++ b/src/qt3utils/applications/qt3scan/controller.py
@@ -833,7 +833,8 @@ class QT3ScanHyperSpectralApplicationController:
             # ax.axvline(max_range, color='k', linestyle='--')
             ax.axvspan(min_range, max_range, alpha=0.1, color='k', label='Filter Range')
 
-        ax.axhline(self.raw_bg_counts, linestyle='--', alpha=0.5, color='chocolate', label='BG')
+        if self.raw_bg_counts != 0.:
+            ax.axhline(self.raw_bg_counts, linestyle='--', alpha=0.5, color='chocolate', label='BG')
 
         if self.counts_aggregation_option == 'Axes-Weighted-Mean':
             ax.axvline(self.scanned_raw_counts[index_y, index_x], alpha=0.5, color='r', label='center')

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -4,6 +4,7 @@ import importlib.resources
 import logging
 import tkinter as tk
 from threading import Thread
+from tkinter import messagebox
 from typing import Any, Protocol, Optional, Callable, List
 
 import matplotlib
@@ -778,6 +779,16 @@ class MainTkApplication:
                 self.go_to_position()
 
     def start_scan(self) -> None:
+        if self.application_controller.data_saved_once is False:
+            stored_data_shape = np.prod(np.shape(self.application_controller.scanned_count_rate))
+            data_shape_product = np.prod(stored_data_shape)
+            if data_shape_product > 0:
+                proceed = messagebox.askyesno("WARNING: Scan NOT SAVED",
+                                              "The previous scan was not saved. Are you sure you want to proceed with "
+                                              "a new scan? All DATA will be LOST.")
+                if not proceed:
+                    return
+
         self.view.sidepanel.startButton.config(state=tk.DISABLED)
         self.view.sidepanel.go_to_z_button.config(state=tk.DISABLED)
         self.view.sidepanel.gotoButton.config(state=tk.DISABLED)

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -131,7 +131,8 @@ class ScanImage:
                                              app_controller.current_y - app_controller.step_size / 2.0])
 
         if self.cbar is None:
-            self.cbar = self.fig.colorbar(self.artist, ax=self.ax)
+            self.cbar: plt.Colorbar = self.fig.colorbar(self.artist, ax=self.ax)
+            self.cbar.formatter.set_useOffset(False)
         else:
             self.cbar.update_normal(self.artist)
 

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -336,36 +336,39 @@ class SidePanel:
         tk.Label(frame, text="View Settings", font='Helvetica 16').grid(row=row, column=0, pady=10)
         row += 1
         self.set_color_map_button = tk.Button(frame, text="Set Color")
-        self.set_color_map_button.grid(row=row, column=0, pady=(2, 15))
+        self.set_color_map_button.grid(row=row, column=0, pady=2)
         self.mpl_color_map_entry = tk.Entry(frame, width=10)
         self.mpl_color_map_entry.insert(10, 'gray')
-        self.mpl_color_map_entry.grid(row=row, column=1, pady=(2, 15))
+        self.mpl_color_map_entry.grid(row=row, column=1, pady=2)
 
         self.log10Button = tk.Button(frame, text="Log10")
-        self.log10Button.grid(row=row, column=2, pady=(2, 15))
+        self.log10Button.grid(row=row, column=2, pady=2)
 
         row += 1
         tk.Label(frame, text="Spectral Confocal", font='Helvetica 12').grid(row=row, column=0, pady=2)
         row += 1
         self.set_filter_range_button = tk.Button(frame, text="Set Range")
-        self.set_filter_range_button.grid(row=row, column=0, pady=(2, 15))
+        self.set_filter_range_button.grid(row=row, column=0)
         self.range_min_entry = tk.Entry(frame, width=10)
         self.range_min_entry.insert(10, f'{-np.inf}')
-        self.range_min_entry.grid(row=row, column=1, pady=(2, 15))
+        self.range_min_entry.grid(row=row, column=1)
         self.range_max_entry = tk.Entry(frame, width=10)
         self.range_max_entry.insert(10, f'{np.inf}')
-        self.range_max_entry.grid(row=row, column=2, pady=(2, 15))
+        self.range_max_entry.grid(row=row, column=2)
 
         row += 1
         self.set_count_aggregation_button = tk.Button(frame, text="Set Counts Aggregation")
-        self.set_count_aggregation_button.grid(row=row, column=0, pady=(2, 15))
+        self.set_count_aggregation_button.grid(row=row, column=0)
         self.count_aggregation_option = tk.StringVar(frame)
         self.count_aggregation_option.set(list(STANDARD_COUNT_AGREGATION_METHODS.keys())[0])
         self.count_aggregation_menu = tk.OptionMenu(frame,
                                               self.count_aggregation_option,
                                               *STANDARD_COUNT_AGREGATION_METHODS.keys(),
                                               )
-        self.count_aggregation_menu.grid(row=row, column=1, columnspan=2, pady=(2, 15))
+        self.count_aggregation_menu.grid(row=row, column=1, columnspan=2)
+
+        row += 1
+        tk.Label(frame, text='', ).grid(row=row, column=0, columnspan=3, pady=10)
 
     def update_go_to_position(self,
                               x: Optional[float] = None,

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -582,6 +582,18 @@ class MainTkApplication:
         When called from the pull-down menu, a popup window opens to prevent GUI freezes
         due to long connection times to the devices (e.g., for spectrometers).
         """
+        # check if last scan was saved
+        if hasattr(self, 'application_controller'):
+            if self.application_controller.data_saved_once is False:
+                stored_data_shape = np.prod(np.shape(self.application_controller.scanned_count_rate))
+                data_shape_product = np.prod(stored_data_shape)
+                if data_shape_product > 0:
+                    proceed = messagebox.askyesno("WARNING: Scan NOT SAVED",
+                                                  "The previous scan was not saved. Are you sure you want to proceed with "
+                                                  "a new scan? All DATA will be LOST.")
+                    if not proceed:
+                        return
+
         logger.info(f"loading {application_controller_name}")
         config = self._open_yaml_config_for_controller(application_controller_name)
 

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -589,9 +589,10 @@ class MainTkApplication:
                 data_shape_product = np.prod(stored_data_shape)
                 if data_shape_product > 0:
                     proceed = messagebox.askyesno("WARNING: Scan NOT SAVED",
-                                                  "The previous scan was not saved. Are you sure you want to proceed with "
-                                                  "a new scan? All DATA will be LOST.")
+                                                  "The previous scan was not saved. Are you sure you want to change "
+                                                  "the controller? All DATA will be LOST.")
                     if not proceed:
+                        self.view.controller_option.set(self.active_application_controller_option)
                         return
 
         logger.info(f"loading {application_controller_name}")
@@ -624,6 +625,8 @@ class MainTkApplication:
         self.view.scan_view.set_rightclick_callback(self.application_controller.scan_image_rightclick_event)
         self.view.position_controller_config_button.bind("<Button>", lambda e: self.application_controller.position_controller.configure_view(self.root_window))
         self.view.daq_config_button.bind("<Button>", lambda e: self.application_controller.daq_controller.configure_view(self.root_window))
+
+        self.active_application_controller_option = self.view.controller_option.get()
 
     def configure_from_yaml(self) -> None:
         """

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -726,8 +726,8 @@ class MainTkApplication:
             logger.debug(f'Filter Range not available for this DAQ. Nothing happens.')
             return
 
-        filter_min = np.float_(self.view.sidepanel.range_min_entry.get())
-        filter_max = np.float_(self.view.sidepanel.range_max_entry.get())
+        filter_min = np.float64(self.view.sidepanel.range_min_entry.get())
+        filter_max = np.float64(self.view.sidepanel.range_max_entry.get())
         self.application_controller.filter_view_range = filter_min, filter_max
 
         if self.application_controller.still_scanning() is False:

--- a/src/qt3utils/applications/qt3scan/main.py
+++ b/src/qt3utils/applications/qt3scan/main.py
@@ -20,7 +20,7 @@ import qt3utils.pulsers.pulseblaster
 from qt3utils.applications.qt3scan.controller import (
     QT3ScanConfocalApplicationController,
     QT3ScanHyperSpectralApplicationController,
-    STANDARD_COUNT_AGREGATION_METHODS
+    STANDARD_COUNT_AGGREGATION_METHODS
 )
 from qt3utils.applications.controllers.utils import make_popup_window_and_take_threaded_action
 from qt3utils.applications.qt3scan.interface import (
@@ -361,11 +361,11 @@ class SidePanel:
         self.set_count_aggregation_button = tk.Button(frame, text="Set Counts Aggregation")
         self.set_count_aggregation_button.grid(row=row, column=0)
         self.count_aggregation_option = tk.StringVar(frame)
-        self.count_aggregation_option.set(list(STANDARD_COUNT_AGREGATION_METHODS.keys())[0])
+        self.count_aggregation_option.set(list(STANDARD_COUNT_AGGREGATION_METHODS.keys())[0])
         self.count_aggregation_menu = tk.OptionMenu(frame,
-                                              self.count_aggregation_option,
-                                              *STANDARD_COUNT_AGREGATION_METHODS.keys(),
-                                              )
+                                                    self.count_aggregation_option,
+                                                    *STANDARD_COUNT_AGGREGATION_METHODS.keys(),
+                                                    )
         self.count_aggregation_menu.grid(row=row, column=1, columnspan=2)
 
         row += 1
@@ -699,8 +699,6 @@ class MainTkApplication:
             self.view.scan_view.update(self.application_controller)
             self.view.canvas.draw()
 
-
-
     def log_scan_image(self) -> None:
         self.view.scan_view.log_data = not self.view.scan_view.log_data
         if self.application_controller.still_scanning() is False:
@@ -833,14 +831,13 @@ class MainTkApplication:
 
     def load_scan(self):
         afile = tk.filedialog.askopenfilename(filetypes=self.application_controller.allowed_file_save_formats(),
-                                                defaultextension=self.application_controller.default_file_format())
+                                              defaultextension=self.application_controller.default_file_format())
         if afile is None or afile == '':
             return  # selection was canceled.
 
         logger.info(f'Loading data from {afile}')
         self.application_controller.load_scan(afile)
 
-        # self.set_filter_range()
         if hasattr(self.application_controller, 'filter_view_range'):
             self.view.sidepanel.range_min_entry.delete(0, tk.END)
             self.view.sidepanel.range_min_entry.insert(0, str(self.application_controller.filter_view_range[0]))
@@ -849,7 +846,6 @@ class MainTkApplication:
 
         if hasattr(self.application_controller, 'counts_aggregation_option'):
             self.view.sidepanel.count_aggregation_option.set(self.application_controller.counts_aggregation_option)
-
 
         if self.application_controller.still_scanning() is False:
             self.view.scan_view.update(self.application_controller)

--- a/src/qt3utils/datagenerators/piezoscanner.py
+++ b/src/qt3utils/datagenerators/piezoscanner.py
@@ -164,15 +164,12 @@ class CounterAndScanner:
         if self.stage_controller:
             min_val = np.max([min_val, self.stage_controller.minimum_allowed_position])
             max_val = np.min([max_val, self.stage_controller.maximum_allowed_position])
-        else:
-            min_val = np.max([min_val, 0.0])
-            max_val = np.min([max_val, 80.0])
 
         self.start()
         raw_counts = self.scan_axis(axis, min_val, max_val, step_size)
         self.stop()
         self.post_stop()
-        axis_vals = np.arange(min_val, max_val, step_size)
+        axis_vals = np.arange(min_val, max_val + step_size, step_size)
         count_rates = [self.sample_count_rate(count) for count in raw_counts]
 
         optimal_position = axis_vals[np.argmax(count_rates)]

--- a/src/qt3utils/datagenerators/spectrometers/princeton.py
+++ b/src/qt3utils/datagenerators/spectrometers/princeton.py
@@ -66,9 +66,9 @@ class LightfieldApplicationManager:
             if self.experiment.IsValid(setting, value):
                 self.experiment.SetValue(setting, value)
             else:
-                raise Exception(f'Invalid value: {value} for setting: {setting}.')
+                raise Exception(f'Invalid value: {value} for setting: {setting}, with value {value}.')
         else:
-            raise Exception(f'Invalid setting: {setting}.')
+            raise Exception(f'Invalid setting: {setting}, with value {value}, with value {value}.')
 
     def get(self, setting: Any) -> Any:
         """


### PR DESCRIPTION
In this pull request, multiple functionalities have been added to the Qt3Scan GUI and controllers. 

1. DAQ clock rate is stored internally in the controller for the collected dataset. This prevents any issues arising when changing the DAQ clock rate before you save the collected data.
2. In addition to the clock rate, now the DAQ and Scanner last config dicts are stored right before the scan starts. This is important to later store this kind of metadata.
3. Added functionality to the spectral confocal scans, so that the plotted images can be processed in two ways:
   1. _Choose the data aggregation method_: Since each pixel in the scan contains an entire spectrum, the data must somehow be processed to be put in an image. Traditionally, a sum over the entire spectrum would suffice. Here, we give the user a choice to perform more nuanced analysis with choices such as plotting the mean, max, or min counts for each pixel, or plotting the wavelength at which the max and min are, or even plotting the weighted-by-counts wavelength (which gives the central wavelength of a single peak if the spectrum contains only one peak, without requiring a fit).
   2. _Filter the wavelength range_: instead of using the entire spectrum to aggregate data, this functionality allows the user to select only a specific range of wavelengths on which the aggregation method will act on. This range is also depicted in the individual scan data (upon a right-click on a plot pixel).
4. Added more parameters to the stored data: 
   1. Filter range
   2. Aggregation method
   3. DAQ configuration
   4. Scanner configuration

   With npz filetype, the daq_config and scanner_config are saved as additional keys. In order to read them, allow_pickle=True in the np.load(...) method must be used. With h5 filetype, the daq_config and scanner_config are saved as a json-converted dicts in the file attributes. (e.g., h5file.attrs['daq_config']).
6. Load Scan: Now you can load a saved scan and view it immediately. All formats other than '.npy' are supported. Since the filter range and aggregation method are stored, the user can even recover the process which resulted in the plot they last saw on the GUI.
7. 'Go to' after scan checkbox: After the end of a scan, the 'Go To Position' method will run once if the checkbox is set to active.
8. Added "Optimize axis" functionality for spectrometer-based DAQs
9. Fixed "Optimize axis" bug (axis values were missing last value with previous changes in main).
